### PR TITLE
DEV: fix paths in coverage reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           pip install --upgrade nox
 
       - name: "Run nox for ${{ matrix.python-version }}"
-        run: "nox -s test-${{ matrix.python-version }} -- --cov-report lcov:lcov-${{matrix.os}}-${{matrix.python-version}}.lcov --cov-report term --cov-append --cov diverse_seq"
+        run: "nox -s test_coveralls-${{ matrix.python-version }} -- --cov-report lcov:lcov-${{matrix.os}}-${{matrix.python-version}}.lcov --cov-report term --cov-append --cov diverse_seq"
 
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@v2

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,7 +5,7 @@ _py_versions = range(10, 13)
 
 @nox.session(python=[f"3.{v}" for v in _py_versions])
 def test(session):
-    session.install("-e.[test]")
+    session.install(".[test]")
     session.chdir("tests")
     session.run(
         "pytest",
@@ -16,7 +16,7 @@ def test(session):
 
 @nox.session(python=["3.12"])
 def testcov(session):
-    session.install("-e.[test]")
+    session.install(".[test]")
     session.chdir("tests")
     session.run(
         "pytest",
@@ -24,4 +24,15 @@ def testcov(session):
         "html",
         "--cov",
         "diverse_seq",
+    )
+
+
+@nox.session(python=[f"3.{v}" for v in _py_versions])
+def test_coveralls(session):
+    session.install("-e.[test]")
+    session.chdir("tests")
+    session.run(
+        "pytest",
+        "-x",
+        *session.posargs,  # propagates sys.argv to pytest
     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,7 +5,7 @@ _py_versions = range(10, 13)
 
 @nox.session(python=[f"3.{v}" for v in _py_versions])
 def test(session):
-    session.install(".[test]")
+    session.install("-e.[test]")
     session.chdir("tests")
     session.run(
         "pytest",
@@ -16,7 +16,7 @@ def test(session):
 
 @nox.session(python=["3.12"])
 def testcov(session):
-    session.install(".[test]")
+    session.install("-e.[test]")
     session.chdir("tests")
     session.run(
         "pytest",

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,6 +2,8 @@ import nox
 
 _py_versions = range(10, 13)
 
+nox.options.sessions = ["test", "testcov"]
+
 
 @nox.session(python=[f"3.{v}" for v in _py_versions])
 def test(session):


### PR DESCRIPTION
Installs `diverse_seq` in editable mode when running the tests to ensure correct paths in the coverage reports