### PR TITLE
Fix newick output

### DIFF
--- a/src/diverse_seq/cli.py
+++ b/src/diverse_seq/cli.py
@@ -457,7 +457,6 @@ def ctree(
     hide_progress: bool,
 ):
     """Quickly compute a cluster tree based on kmers for a collection of sequences."""
-
     if seqfile.suffix != ".dvseqs":
         dvs_util.print_colour(
             "Sequence data needs to be preprocessed, use 'dvs prep'",
@@ -492,7 +491,6 @@ def ctree(
         seqs[name] = arr2str_app(record.read())  # pylint: disable=not-callable
 
     seqs = make_unaligned_seqs(seqs, moltype=moltype)
-
     app = dvs_cluster.dvs_par_ctree(
         k=k,
         sketch_size=sketch_size,
@@ -504,6 +502,9 @@ def ctree(
         show_progress=not hide_progress,
     )
     tree = app(seqs)  # pylint: disable=not-callable
+    if not tree:
+        dvs_util.print_colour(tree, "red")
+        sys.exit(1)
     tree.write(outpath)
 
 

--- a/src/diverse_seq/cluster.py
+++ b/src/diverse_seq/cluster.py
@@ -231,11 +231,10 @@ def make_cluster_tree(
             tree_dict.pop(right_index),
         )
         node_index += 1
-
-    tree = make_tree(str(tree_dict[node_index - 1]))
-
+    # use string representation and then remove quotes
+    treestring = str(tree_dict[node_index - 1]).replace("'", "")
+    tree = make_tree(treestring=treestring, underscore_unmunge=True)
     progress.update(tree_task, completed=1, total=1)
-
     return tree
 
 
@@ -297,7 +296,6 @@ class dvs_par_ctree(ClusterTreeBase):
             mash_canonical_kmers=mash_canonical_kmers,
             show_progress=show_progress,
         )
-
         if parallel:
             if max_workers is None:
                 max_workers = multiprocessing.cpu_count()

--- a/src/diverse_seq/distance.py
+++ b/src/diverse_seq/distance.py
@@ -159,7 +159,6 @@ def mash_distances(
     numpy.ndarray
         Pairwise mash distances between sequences.
     """
-
     if progress is None:
         progress = Progress(disable=True)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -253,9 +253,7 @@ def test_ctree(
 ):
     outpath = tmp_dir / "out.tre"
 
-    args = (
-        f"-s {processed_seq_path} -o {outpath} -d {distance} -k {k} -np {max_workers}"
-    )
+    args = f"-s {processed_seq_path} -o {outpath} -d {distance} -k {k} -np {max_workers} -hp"
     if sketch_size is not None:
         args += f" --sketch-size {sketch_size}"
     args = args.split()


### PR DESCRIPTION
## Summary by Sourcery

Fix the Newick output formatting by removing quotes from the string representation of the tree dictionary. Enhance the 'ctree' function to handle cases where the tree is not generated by printing an error message and exiting. Update the test for 'ctree' to include the '-hp' flag in the arguments.

Bug Fixes:
- Fix the Newick tree output by ensuring the string representation of the tree dictionary is correctly formatted without quotes.

Enhancements:
- Add a check in the 'ctree' function to print an error message and exit if the tree is not generated.

Tests:
- Update the 'test_ctree' function to include the '-hp' flag in the arguments for testing.