### PR TITLE
MAINT: updates and tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,8 @@ doc  = ["click",
         "nbsphinx",
         "numpydoc",
         "pandas",
-        "plotly"
+        "plotly",
+        "requests",
         ]
 
 [project.scripts]

--- a/src/diverse_seq/distance.py
+++ b/src/diverse_seq/distance.py
@@ -258,7 +258,7 @@ def mash_sketch(
     sketch_size: int,
     num_states: int,
     mash_canonical: bool,
-) -> BottomSketch:
+) -> BottomSketch:  # pragma: no cover
     """Find the mash sketch for a sequence array.
 
     Parameters


### PR DESCRIPTION
## Summary by Sourcery

Enhance the test suite by adding a new fixture and a test for pickle roundtrip of HDF5 data store. Update the build configuration to include 'requests' as a dependency. Exclude the 'mash_sketch' function from test coverage.

Enhancements:
- Add a 'pragma: no cover' comment to the 'mash_sketch' function to exclude it from test coverage.

Build:
- Add 'requests' to the list of dependencies in 'pyproject.toml'.

Tests:
- Add a new test fixture 'brca1_hdf5_dstore' for HDF5 data store testing.
- Introduce a test 'test_pickle_roundtrip' to verify the pickle serialization and deserialization of 'brca1_hdf5_dstore'.