### PR TITLE
REL: bump version to 2024.11.8a1

### DIFF
--- a/src/diverse_seq/__init__.py
+++ b/src/diverse_seq/__init__.py
@@ -4,4 +4,4 @@
 # found by h5py
 import hdf5plugin  # noqa
 
-__version__ = "2024.9.2a1"
+__version__ = "2024.11.8a1"


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Bump the project version to 2024.11.8a1.