### PR TITLE
REL: bumped version to 2024.12.26a1

### DIFF
--- a/src/diverse_seq/__init__.py
+++ b/src/diverse_seq/__init__.py
@@ -4,4 +4,4 @@
 # found by h5py
 import hdf5plugin  # noqa
 
-__version__ = "2024.11.22a1"
+__version__ = "2024.12.26a1"


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Bump version to 2024.12.26a1.