### PR TITLE
DOC: add missing DOI's

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -59,6 +59,7 @@
 
 @article{lake.1994.procnatlacadsciua,
 	author = {Lake, J A},
+	doi = {10.1073/pnas.91.4.1455},
 	journal = {Proc Natl Acad Sci U S A},
 	language = {eng},
 	number = {4},
@@ -132,6 +133,7 @@
 
 @article{saitou.1987.mol.biol.evol,
 	author = {Saitou, N and Nei, M},
+	doi = {10.1093/oxfordjournals.molbev.a040454},
 	journal = {Mol. Biol. Evol.},
 	number = {4},
 	pages = {406--425},


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add missing DOIs to the bibliography.