### PR TITLE
DOC: add installation instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@
 
 You can read more about the methods implemented in `diverse-seq` in the preprint [here](https://biorxiv.org/cgi/content/short/2024.11.10.622877v1).
 
+### Installation
+
+`diverse-seq` can be installed from PyPI as follows
+
+```
+pip install diverse-seq
+```
+
 ### `dvs prep`: preparing the sequence data
 
 Convert sequence data into a more efficient format for the diversity assessment. This must be done before running either the `nmost` or `max` commands.


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add installation instructions to the README, detailing how to install `diverse-seq` from PyPI using pip.