### PR TITLE
DEV: specify destn dir for rtd

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,8 +12,9 @@ build:
     python: "3.13"
   commands:
     - pip install ".[doc]"
+    - mkdir -p $READTHEDOCS_OUTPUT/html
     - mkdocs --version
-    - mkdocs build --clean
+    - mkdocs build --clean --site-dir $READTHEDOCS_OUTPUT/html
 
 mkdocs:
   configuration: mkdocs.yml


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Specifies the destination directory for mkdocs build command to ensure the generated HTML files are placed in the correct output directory.