### PR TITLE
DEV: add an `extra` install option and modify docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,10 +15,13 @@ pip install diverse-seq
 > **NOTE**
 > If you experience any errors during installation, we recommend using [uv pip](https://docs.astral.sh/uv/). This command provides much better error messages than the standard `pip` command. If you cannot resolve the installation problem, please [open an issue](https://github.com/HuttleyLab/DiverseSeq/issues).
 
-#### Install to replicate the documentation
+#### The `extra` install option
 
-To reproduce the examples presented in this documentation, you need extra components. You can install these as follows
+To get the additional components for working within Jupyter notebooks, or just to reproduce all the examples in the documentation, do the install as follows
 
 ```
-pip install "diverse-seq[doc]"
+pip install "diverse-seq[extra]"
 ```
+
+> **Note**
+> The first usage of `diverse-seq` is slow because both `cogent3` and `diverse-seq` are compiling some functions. This is a one-time cost.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,24 +53,14 @@ test = [
     "pytest-cov",
     "pytest-xdist",
 ]
-doc  = ["click",
-        "cogent3[extra]",
-        "ipykernel",
-        "ipython",
-        "ipywidgets",
-        "jupyter_client",
-        "jupyterlab",
-        "jupytext",
-        "kaleido",
-        "mkdocs>=1.6.1",
-        "markdown-exec[ansi]>=1.10.0",
-        "mkdocs-jupyter>=0.25.1",
-        "markdown>=3.7",
-        "nbconvert>5.4",
-        "nbformat",
-        "numpydoc",
-        "plotly",
-        ]
+doc  = [
+    "diverse_seq[extra]",
+    "mkdocs>=1.6.1",
+    "markdown-exec[ansi]>=1.10.0",
+    "mkdocs-jupyter>=0.25.1",
+    "markdown>=3.7",
+    "numpydoc",
+]
 dev = [
     "cogapp",
     "docformatter",
@@ -78,6 +68,19 @@ dev = [
     "ruff==0.11.0",
     "diverse_seq[test]",
     "diverse_seq[doc]",
+]
+extra = [
+    "cogent3[extra]",
+    "ipykernel",
+    "ipython",
+    "ipywidgets",
+    "jupyter_client",
+    "jupyterlab",
+    "jupytext",
+    "kaleido",
+    "nbconvert>5.4",
+    "nbformat",
+    "plotly",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary by Sourcery

Adds an `extra` install option to include components for working within Jupyter notebooks and to reproduce all examples in the documentation. Modifies the documentation to reflect the new install option and to warn users about the first usage slowness due to function compilation.

Enhancements:
- Introduces an `extra` install option to include components for working within Jupyter notebooks and reproducing documentation examples.
- Updates the documentation to use the new `extra` install option.
- Adds a note to the documentation to warn users about the first usage slowness due to function compilation.