### PR TITLE
BUG: better messages if insufficient data, fixes #137

### DIFF
--- a/src/diverse_seq/cli.py
+++ b/src/diverse_seq/cli.py
@@ -204,12 +204,13 @@ def prep(
             in_dstore = convert2dstore(seqdir)  # pylint: disable=not-callable
         else:
             in_dstore = c3_data_store.DataStoreDirectory(source=seqdir, suffix=suffix)
-            if not len(in_dstore):
-                dvs_util.print_colour(
-                    f"{seqdir} contains no files matching '*.{suffix}'",
-                    "red",
-                )
-                sys.exit(1)
+
+        if len(in_dstore) < 5:
+            msg = f"Num files matching '{seqdir}/*.{suffix}' = {len(in_dstore)} < 5."
+            if seqdir.is_dir():
+                msg = f"{msg} Did you mean to pass a file path instead?"
+            dvs_util.print_colour(msg, "red")
+            sys.exit(1)
 
         if limit is not None:
             members = in_dstore.completed[:]

--- a/src/diverse_seq/cli.py
+++ b/src/diverse_seq/cli.py
@@ -150,7 +150,7 @@ def demo_data(outpath: Path) -> None:
     "--seqdir",
     required=True,
     type=Path,
-    help="directory containing sequence files",
+    help="one sequence file, or a directory containing multiple sequence files",
 )
 @_suffix
 @click.option(

--- a/src/diverse_seq/cli.py
+++ b/src/diverse_seq/cli.py
@@ -111,6 +111,7 @@ _seqfile = click.option(
     "--seqfile",
     required=True,
     type=Path,
+    callback=dvs_util._check_h5_dstore,
     help="path to .dvseqs file",
 )
 _k = click.option("-k", type=int, default=6, help="k-mer size")
@@ -319,6 +320,11 @@ def max(  # noqa: A001
         sys.exit(1)
 
     seqids = dvs_data_store.get_seqids_from_store(seqfile)
+    if len(seqids) < min_size:
+        msg = f"Num seqs in {seqfile}={len(seqids)} < {min_size=}. Nothing to do!"
+        dvs_util.print_colour(msg, "red")
+        sys.exit(1)
+
     if include and not set(include) <= set(seqids):
         dvs_util.print_colour(
             f"provided {include=} not in the sequence data",
@@ -332,7 +338,7 @@ def max(  # noqa: A001
     rng = numpy.random.default_rng(seed=seed)
     rng.shuffle(seqids)
 
-    limit = 2 if test_run else limit
+    limit = min_size + 1 if test_run else limit
     if limit is not None:
         seqids = seqids[:limit]
 
@@ -420,6 +426,10 @@ def nmost(
         sys.exit(1)
 
     seqids = dvs_data_store.get_seqids_from_store(seqfile)
+    if len(seqids) < number:
+        msg = f"Num seqs in {seqfile}={len(seqids)} < {number=}. Nothing to do!"
+        dvs_util.print_colour(msg, "red")
+        sys.exit(1)
 
     if include and not set(include) <= set(seqids):
         dvs_util.print_colour(

--- a/src/diverse_seq/util.py
+++ b/src/diverse_seq/util.py
@@ -4,6 +4,7 @@ import math
 import os
 import pathlib
 import re
+import sys
 import typing
 
 import numpy
@@ -159,6 +160,24 @@ def _hide_progress(
     hide_progress: str,
 ) -> bool:
     return True if "DVS_HIDE_PROGRESS" in os.environ else hide_progress
+
+
+def _check_h5_dstore(
+    ctx: "Context",  # noqa: ARG001
+    param: "Option",  # noqa: ARG001
+    path: pathlib.Path,
+) -> pathlib.Path:
+    """makes sure minimum number of sequences are in the store"""
+    from diverse_seq import data_store
+
+    seqids = data_store.get_seqids_from_store(path)
+    min_num = 5
+    if len(seqids) >= min_num:
+        return path
+
+    msg = f"SKIPPING: '{path}' does not have ≥{min_num} sequences!"
+    print_colour(msg, "red")
+    sys.exit(1)
 
 
 class _printer:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -289,13 +289,40 @@ def test_prep_force(runner, tmp_path):
     args = f"-s {one_path} -o {outpath} -F".split()
     r = runner.invoke(dvs_prep, args)
     assert r.exit_code == 0, r.output
-@pytest.fixture(params=[3, 7])
-def too_few_seqs(request, tmp_path):
-    num_seqs = request.param
+
+
+@pytest.fixture(params=[True, False])
+def prep_too_few(request, tmp_path):
+    import diverse_seq
+
+    data_path = tmp_path / "sample.fasta"
+    return_dir = request.param
+    # when processing a directory of files, prep
+    # extracts a single seq from each file
+    data = diverse_seq.load_sample_data()
+    if not return_dir:
+        ret_path = data_path
+        data = data.take_seqs(data.names[:3])
+    else:
+        ret_path = data_path.parent
+
+    data.write(data_path)
+    return ret_path
+
+
+def test_prep_too_few_seqs(prep_too_few, runner, tmp_path):
+    out_path = tmp_path / "too_few.dvseqs"
+    args = f"-s {prep_too_few} -sf fasta -o {out_path}".split()
+    r = runner.invoke(dvs_prep, args)
+    assert r.exit_code == 1, r.output
+
+
+@pytest.fixture
+def too_few_seqs(tmp_path):
     import diverse_seq
 
     data = diverse_seq.load_sample_data()
-    data = data.take_seqs(data.names[:num_seqs])
+    data = data.take_seqs(data.names[:7])
     data_path = tmp_path / "sample.fasta"
     data.write(data_path)
     return data_path


### PR DESCRIPTION
We now exit with a warning if too few sequences would result from the prep step.

We now exit with a warning if there are two few sequences for the arguments
provided to nmost, max and ctree.

## Summary by Sourcery

Improve error handling by exiting with a warning message when there is insufficient data for the prep, nmost, and max commands.

Bug Fixes:
- Exit with a warning if too few sequences result from the prep step.
- Exit with a warning if there are too few sequences for the arguments provided to nmost, max and ctree.
- Fixes an issue where the program would proceed with insufficient data, leading to errors or unexpected results later in the pipeline.

Tests:
- Add tests to verify that the program exits with an error message when there is insufficient data for the prep, nmost, and max commands.