### PR TITLE
MAINT: fix candidate error for publication bot failure

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -170,8 +170,7 @@ For selecting representative sequences for large-scale analyses, we recommend us
 |   No overlap | `AAAA` | `TTTT` | 1.0 |
 +--------------+--------+--------+-----+
 | Intermediate | `ATCG` | `ATCC` | 0.5 |
-+==============+========+========+=====+
-
++--------------+--------+--------+-----+
 
 # Acknowledgements
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Fix table formatting and section heading in the paper's markdown documentation.