### PR TITLE
Prep for release

### DIFF
--- a/docs/apps.py
+++ b/docs/apps.py
@@ -1,6 +1,8 @@
 # %% [markdown]
 #
 # We provide programmatic access to `diverse_seq` functions as [cogent3 apps](https://cogent3.org/doc/app/index.html). The `dvs` apps mirror the capabilities of their command line counterparts with two key differences: the input and outputs. There is no data transformation step. Just use `cogent3` to [load the sequence collection](https://cogent3.org/doc/cookbook/loading_sequences.html) (aligned or otherwise) and pass it to an app instance. The `dvs_nmost` and `dvs_max` will identify the sequences to keep and return the same input data type that contains just those sequences.
+# > **Note**
+# We now enforce using `new_type` cogent3 objects so users need to do the same (see the cogent3 ["Migration to new type core objects"](https://cogent3.org/#features-announcements) announcement).
 
 # ## What apps are available?
 # We use the `cogent3` capabilities for displaying the installed apps and getting help on them.

--- a/src/diverse_seq/__init__.py
+++ b/src/diverse_seq/__init__.py
@@ -12,7 +12,7 @@ os.environ["COGENT3_NEW_TYPE"] = "1"
 if typing.TYPE_CHECKING:
     from cogent3.core.new_alignment import SequenceCollection
 
-__version__ = "2025.3.24"
+__version__ = "2025.5.7"
 
 
 def load_sample_data() -> "SequenceCollection":


### PR DESCRIPTION
## Summary by Sourcery

Prepare for release by updating package version and clarifying documentation on object types

Documentation:
- Add note enforcing use of cogent3 new_type objects in app documentation

Chores:
- Bump diverse_seq version to 2025.5.7 for release prep