### PR TITLE
DEV: pin python3.13.3 due to incompatibility of 3.13.4 with numba

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
-        exclude:
-          - os: windows-latest
-            python-version: "3.13"
+        python-version: ["3.10", "3.11", "3.12", "3.13.3"]
 
     steps:
       - uses: "actions/checkout@v4"
@@ -39,7 +36,7 @@ jobs:
           uv tool install -p venv nox
 
       - name: "Run nox for ${{ matrix.python-version }}"
-        run: "nox -db uv -s test_coveralls-${{ matrix.python-version }} -- --cov-report lcov:lcov-${{matrix.os}}-${{matrix.python-version}}.lcov --cov-report term --cov-append --cov diverse_seq"
+        run: "nox -db uv --force-python python -s test_coveralls -- --cov-report lcov:lcov-${{matrix.os}}-${{matrix.python-version}}.lcov --cov-report term --cov-append --cov diverse_seq"
 
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@v2


### PR DESCRIPTION
## Summary by Sourcery

Pin Python 3.13 in the CI matrix to version 3.13.3 due to a numba incompatibility and streamline the nox test invocation.

CI:
- Pin Python 3.13 in the CI matrix to version 3.13.3 due to numba incompatibility.
- Simplify the nox test invocation to use --force-python python and a unified test_coveralls session.