### PR TITLE
DEV: don't allow errors during doc building to pass

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,9 +14,10 @@ theme:
 
 plugins:
     - mkdocs-jupyter:
+        allow_errors: false
         remove_tag_config:
             remove_input_tags:
-                - hide_code
+              - hide_code
         include_requirejs: true
         execute: true
     - markdown-exec:


### PR DESCRIPTION
## Summary by Sourcery

Disable error skipping during documentation builds by updating the mkdocs-jupyter plugin configuration.

Enhancements:
- Set allow_errors to false in the mkdocs-jupyter plugin to ensure notebook execution errors cause the build to fail.
- Fix the indentation of the hide_code tag under remove_input_tags in mkdocs configuration.