### PR TITLE
MAINT: update to latest cogent3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.10,<3.14"
 dependencies = [
     "attrs",
     "click",
-    "cogent3",
+    "cogent3>=2025.7.10a1",
     "hdf5plugin",
     "h5py!=3.12.0",
     "loky",

--- a/tests/test_data_store.py
+++ b/tests/test_data_store.py
@@ -22,7 +22,7 @@ def brca1_seqs():
 def brca1_5(brca1_seqs):
     seqs = brca1_seqs.take_seqs(["Cat", "Dog", "Wombat", "Horse", "Rat"])
     return make_unaligned_seqs(
-        data={s.name: str(s[:20]) for s in seqs.seqs},
+        {s.name: str(s[:20]) for s in seqs.seqs},
         moltype="dna",
     )
 


### PR DESCRIPTION
## Summary by Sourcery

Update cogent3 dependency to the latest prerelease and adjust affected test to match the updated make_unaligned_seqs signature

Build:
- Bump cogent3 dependency to >=2025.7.10a1

Tests:
- Remove deprecated data= keyword argument in make_unaligned_seqs call in test_data_store.py