### PR TITLE
MAINT: update to latest cogent3 API changes

### DIFF
--- a/docs/apps.py
+++ b/docs/apps.py
@@ -1,8 +1,6 @@
 # %% [markdown]
 #
 # We provide programmatic access to `diverse_seq` functions as [cogent3 apps](https://cogent3.org/doc/app/index.html). The `dvs` apps mirror the capabilities of their command line counterparts with two key differences: the input and outputs. There is no data transformation step. Just use `cogent3` to [load the sequence collection](https://cogent3.org/doc/cookbook/loading_sequences.html) (aligned or otherwise) and pass it to an app instance. The `dvs_nmost` and `dvs_max` will identify the sequences to keep and return the same input data type that contains just those sequences.
-# > **Note**
-# We now enforce using `new_type` cogent3 objects so users need to do the same (see the cogent3 ["Migration to new type core objects"](https://cogent3.org/#features-announcements) announcement).
 
 # ## What apps are available?
 # We use the `cogent3` capabilities for displaying the installed apps and getting help on them.

--- a/src/diverse_seq/__init__.py
+++ b/src/diverse_seq/__init__.py
@@ -14,9 +14,9 @@ __version__ = "2025.7.10"
 
 def load_sample_data() -> "SequenceCollection":
     """load sample data"""
-    from cogent3 import load_aligned_seqs
+    from cogent3 import load_aligned_seqs  # noqa: PLC0415
 
-    from .util import get_sample_data_path
+    from .util import get_sample_data_path  # noqa: PLC0415
 
     path = get_sample_data_path()
-    return load_aligned_seqs(path, moltype="dna", new_type=True).degap()
+    return load_aligned_seqs(path, moltype="dna").degap()

--- a/src/diverse_seq/__init__.py
+++ b/src/diverse_seq/__init__.py
@@ -1,18 +1,15 @@
 """diverse_seq: a tool for sampling diverse biological sequences"""
 
-import os
 import typing
 
 # need to import hdf5plugin here to make sure the plugin path can be
 # found by h5py
 import hdf5plugin  # noqa: F401
 
-os.environ["COGENT3_NEW_TYPE"] = "1"
-
 if typing.TYPE_CHECKING:
-    from cogent3.core.new_alignment import SequenceCollection
+    from cogent3.core.alignment import SequenceCollection
 
-__version__ = "2025.6.26"
+__version__ = "2025.7.10"
 
 
 def load_sample_data() -> "SequenceCollection":

--- a/src/diverse_seq/cli.py
+++ b/src/diverse_seq/cli.py
@@ -140,7 +140,7 @@ def demo_data(outpath: Path) -> None:
     from diverse_seq import load_sample_data
 
     seqs = load_sample_data()
-    seqs.write(outpath, file_format="fasta")
+    seqs.write(outpath, format_name="fasta")
     dvs_util.print_colour(f"Wrote '{outpath!s}'", "green")
 
 

--- a/src/diverse_seq/io.py
+++ b/src/diverse_seq/io.py
@@ -19,7 +19,7 @@ from cogent3.app.data_store import (
     DataStoreDirectory,
     Mode,
 )
-from cogent3.core import new_alphabet
+from cogent3.core import alphabet as c3_alpha
 from cogent3.format import fasta as format_fasta
 from cogent3.parse import fasta, genbank
 
@@ -27,13 +27,13 @@ from diverse_seq import util as dvs_utils
 from diverse_seq.data_store import HDF5DataStore
 from diverse_seq.record import SeqArray
 
-converter_fasta = new_alphabet.convert_alphabet(
+converter_fasta = c3_alpha.convert_alphabet(
     string.ascii_lowercase.encode("utf8"),
     string.ascii_uppercase.encode("utf8"),
     delete=b"\n\r\t- ",
 )
 
-converter_genbank = new_alphabet.convert_alphabet(
+converter_genbank = c3_alpha.convert_alphabet(
     string.ascii_lowercase.encode("utf8"),
     string.ascii_uppercase.encode("utf8"),
     delete=b"\n\r\t- 0123456789",
@@ -54,7 +54,7 @@ class filename_seqname:
     name: str
 
 
-def get_format_parser(seq_path, seq_format):
+def get_format_parser(seq_path: str | Path, seq_format: str) -> typing.Iterable:
     return (
         fasta.iter_fasta_records(seq_path, converter=converter_fasta)
         if seq_format == "fasta"
@@ -70,7 +70,7 @@ def get_format_parser(seq_path, seq_format):
 class dvs_load_seqs:
     """Load and proprocess sequences from seq datastore"""
 
-    def __init__(self, moltype: str = "dna", seq_format: str = "fasta"):
+    def __init__(self, moltype: str = "dna", seq_format: str = "fasta") -> None:
         """load fasta sequences from a data store
 
         Parameters

--- a/src/diverse_seq/record.py
+++ b/src/diverse_seq/record.py
@@ -12,7 +12,6 @@ from cogent3 import get_moltype
 from cogent3.app import composable
 from cogent3.app import data_store as c3_data_store
 from cogent3.app import typing as c3_types
-from cogent3.core import new_sequence as c3_new_seq
 from cogent3.core import sequence as c3_seq
 from numpy import (
     array,
@@ -502,29 +501,6 @@ def _(data: c3_data_store.DataMember, *, dtype: dtype, k: int, moltype: str) -> 
 
 @make_kmerseq.register
 def _(data: c3_seq.Sequence, *, dtype: dtype, k: int, moltype: str) -> KmerSeq:
-    cnvrt = dvs_utils.str2arr(moltype=moltype)
-    vec = lazy_kmers(
-        data=cnvrt(str(data)),  # pylint: disable=not-callable
-        k=k,
-        moltype=moltype,
-        dtype=dtype,
-    )
-    kwargs = {
-        "vector_length": vec.num_states,
-        "dtype": dtype,
-        "source": data.info.source,
-        "name": data.name,
-        "data": vec,
-    }
-
-    return KmerSeq(
-        kcounts=vector(**kwargs),
-        name=kwargs["name"],
-    )
-
-
-@make_kmerseq.register
-def _(data: c3_new_seq.Sequence, *, dtype: dtype, k: int, moltype: str) -> KmerSeq:
     cnvrt = dvs_utils.str2arr(moltype=moltype)
     vec = lazy_kmers(
         data=cnvrt(str(data)),  # pylint: disable=not-callable

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 from cogent3 import load_unaligned_seqs
-from cogent3.core.new_alignment import SequenceCollection
+from cogent3.core.alignment import SequenceCollection
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -362,3 +362,5 @@ def test_demo_data(runner, tmp_path):
 
     r = runner.invoke(demo_data, args)
     assert r.exit_code == 0, r.output
+    result = load_unaligned_seqs(outpath, moltype="dna")
+    assert result.num_seqs > 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from click.testing import CliRunner
 from cogent3 import load_table, load_tree, load_unaligned_seqs
 
 from diverse_seq.cli import ctree as dvs_ctree
+from diverse_seq.cli import demo_data
 from diverse_seq.cli import max as dvs_max
 from diverse_seq.cli import nmost as dvs_nmost
 from diverse_seq.cli import prep as dvs_prep
@@ -353,3 +354,11 @@ def test_max_too_few_seqs(runner, too_few_seqs):
     # exit code should be 1
     r = runner.invoke(dvs_max, args)
     assert r.exit_code == 1, r.output
+
+
+def test_demo_data(runner, tmp_path):
+    outpath = tmp_path / "demo.fa"
+    args = f"-o {outpath}".split()
+
+    r = runner.invoke(demo_data, args)
+    assert r.exit_code == 0, r.output

--- a/tests/test_ctree.py
+++ b/tests/test_ctree.py
@@ -1,7 +1,7 @@
 # pylint: disable=not-callable
 import pytest
 from cogent3 import make_tree
-from cogent3.core.new_alignment import SequenceCollection
+from cogent3.core.alignment import SequenceCollection
 
 from diverse_seq.cluster import dvs_ctree, dvs_par_ctree
 

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -429,17 +429,16 @@ def test_member_to_kmerseq(dstore, seqarray):
     assert_allclose(got.kcounts, expect.kcounts)
 
 
-@pytest.mark.parametrize("new_seq", (True, False))
-def test_make_kmerseq(new_seq):
+def test_make_kmerseq():
     from numpy import min_scalar_type
 
     dtype = min_scalar_type(16)
     raw = "ACGT"
     name = "seq1"
-    seq = make_seq(seq=raw, name=name, moltype="dna", new_type=new_seq)
+    seq = make_seq(seq=raw, name=name, moltype="dna")
     seq.info.source = "source1"
     kseq = make_kmerseq(seq, dtype=dtype, k=2, moltype="dna")
-    alpha = get_moltype("dna", new_type=True).alphabet.get_kmer_alphabet(2)
+    alpha = get_moltype("dna").alphabet.get_kmer_alphabet(2)
     expect_kmers = alpha.to_indices(raw, independent_kmer=False)
     expect = zeros(len(alpha), dtype=dtype)
     expect[expect_kmers] = 1


### PR DESCRIPTION
## Summary by Sourcery

Update diverse_seq to align with the latest cogent3 API by removing deprecated new_type support, replacing old alphabet converters, adjusting I/O and CLI signatures, updating tests and docs, and bumping the package version.

Enhancements:
- Replace new_alphabet.convert_alphabet with c3_alpha.convert_alphabet for sequence format conversion
- Remove deprecated make_kmerseq overload and new_type support in sequence creation and k-mer conversion
- Update CLI and I/O to use new cogent3 API signatures (e.g., seqs.write(format_name), typed get_format_parser)
- Bump package version to 2025.7.10

Documentation:
- Remove outdated note enforcing use of new_type cogent3 objects in documentation

Tests:
- Remove new_type parameter in test_make_kmerseq and adjust expectations for k-mer generation
- Add new test_demo_data case for the demo_data CLI command

Chores:
- Remove COGENT3_NEW_TYPE environment variable setup
- Update SequenceCollection import to use cogent3.core.alignment