### PR TITLE
ENH: added a new app for computing the delta-jsd for a single sequence

### DIFF
--- a/.hgignore
+++ b/.hgignore
@@ -37,3 +37,6 @@ working/*
 .ruff_cache/*
 jats/*
 .venv/*
+.mypy_cache/*
+paper/*
+site/*

--- a/docs/apps.py
+++ b/docs/apps.py
@@ -81,7 +81,9 @@ dvs_djsd
 
 # %%
 name_deltas = [dvs_djsd(seq) for seq in query_seqs.seqs]
-table = cogent3.make_table(header=["seqname", "delta_jsd"], data=name_deltas, index_name="seqname")
+table = cogent3.make_table(
+    header=["seqname", "delta_jsd"], data=name_deltas, index_name="seqname"
+)
 table = table.sorted(reverse="delta_jsd")
 table.head()
 

--- a/docs/apps.py
+++ b/docs/apps.py
@@ -51,6 +51,44 @@ result = dvs_max(seqs)
 result
 
 # %% [markdown]
+# ## Using dvs_delta_jsd
+# The `dvs_delta_jsd` app computes the delta JSD values for a single sequence against a reference set of sequences. It returns a tuple of sequence name, delta JSD value.
+#
+# > **Note**
+# > There is no command line interface for this app.
+#
+# Say we have a reference group of sequences, `ref_seqs`. We want to evaluate each sequence in a set of query sequences to see what their delta JSD values are against the reference set. These values allow us, for example, to select a sequence that is highly diverged from all sequences in the reference set, or one which is very similar to a sequence in the reference set.
+#
+# For this example, we define `ref_seqs` as the first 10 sequences in our sample data.
+
+# %%
+ref_seqs = seqs.take_seqs(seqs.names[:10])
+ref_seqs
+
+# %% [markdown]
+# We define our query group as the remaining sequences.
+
+# %%
+query_seqs = seqs.take_seqs(seqs.names[:10], negate=True)
+query_seqs
+
+# %%
+dvs_djsd = cogent3.get_app("dvs_delta_jsd", seqs=ref_seqs, moltype="dna", k=8)
+dvs_djsd
+
+# %% [markdown]
+# We now compute the delta JSD values for each sequence in `query_seqs` against `ref_seqs` and make a table from the results. We just display the top few records.
+
+# %%
+name_deltas = [dvs_djsd(seq) for seq in query_seqs.seqs]
+table = cogent3.make_table(header=["seqname", "delta_jsd"], data=name_deltas, index_name="seqname")
+table = table.sorted(reverse="delta_jsd")
+table.head()
+
+# %% [markdown]
+# And the conclusion is that the `Bandicoot` (a marsupial) sequence is the most divergent from the reference set (which are all Eutherian, or "placental", mammals).
+
+# %% [markdown]
 # ## Using dvs_ctree
 
 # %%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ dvs = "diverse_seq.cli:main"
 [project.entry-points."cogent3.app"]
 dvs_nmost = "diverse_seq.records:dvs_nmost"
 dvs_max = "diverse_seq.records:dvs_max"
+dvs_delta_jsd = "diverse_seq.records:dvs_delta_jsd"
 dvs_ctree = "diverse_seq.cluster:dvs_ctree"
 dvs_par_ctree = "diverse_seq.cluster:dvs_par_ctree"
 

--- a/src/diverse_seq/records.py
+++ b/src/diverse_seq/records.py
@@ -816,9 +816,12 @@ class dvs_delta_jsd:
 
         records = [self._s2k(degapped.get_seq(name)) for name in degapped.names]
         self._sr = SummedRecords.from_records(records)
+        self.moltype = moltype
 
     def main(self, seq: c3_types.SeqType) -> tuple[str, float]:
-        record = self._s2k(seq.degap())
+        if seq.moltype.name != self.moltype:
+            seq = seq.to_moltype(self.moltype)
+
         seq = seq.degap()
         if len(seq) == 0:
             return seq.name, numpy.nan

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -213,7 +213,7 @@ def test_serialisable_nmost(brca1_coll, tmp_path, app_name):
     select = get_app(app_name, k=2)
     writer = get_app("write_db", data_store=outstore)
     app = select + writer
-    got = app(brca1_coll)  # pylint: disable=not-callable
+    _ = app(brca1_coll)  # pylint: disable=not-callable
     assert len(outstore.completed) == 1
 
 

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -241,3 +241,14 @@ def test_dvs_delta_jsd_zero_length_query():
     name, delta = app(query)  # pylint: disable=not-callable
     assert name == "s3"
     assert numpy.isnan(delta)
+
+
+def test_dvs_delta_jsd_moltype():
+    data = {"s1": "ACGTA", "s2": "ACGTA"}
+    seqs = make_unaligned_seqs(data, moltype="dna")
+    app = dvs_records.dvs_delta_jsd(seqs=seqs, k=1, moltype="dna")
+    query = make_seq("ACAAA", name="s3", moltype="dna")
+    _, expect = app(query)  # pylint: disable=not-callable
+    query = make_seq("ACAAA", name="s3", moltype="text")
+    _, got = app(query)  # pylint: disable=not-callable
+    assert expect == got

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,8 +1,11 @@
+import numpy
 import pytest
 from cogent3 import (
     get_app,
     load_aligned_seqs,
     load_unaligned_seqs,
+    make_aligned_seqs,
+    make_seq,
     make_unaligned_seqs,
     open_data_store,
 )
@@ -221,3 +224,20 @@ def test_select_return_type(brca1_alignment, app_name, aligned):
     select = get_app(app_name, k=2)
     got = select(coll)  # pylint: disable=not-callable
     assert isinstance(got, coll.__class__)
+
+
+def test_dvs_delta_jsd_zero_length_in_ref():
+    data = {"s1": "ACGT-A", "s2": "------"}
+    seqs = make_aligned_seqs(data, moltype="dna")
+    with pytest.raises(ValueError):
+        dvs_records.dvs_delta_jsd(seqs=seqs, k=1)
+
+
+def test_dvs_delta_jsd_zero_length_query():
+    data = {"s1": "ACGTA", "s2": "ACGTA"}
+    seqs = make_unaligned_seqs(data, moltype="dna")
+    app = dvs_records.dvs_delta_jsd(seqs=seqs, k=1, moltype="dna")
+    query = make_seq("", name="s3", moltype="dna")
+    name, delta = app(query)  # pylint: disable=not-callable
+    assert name == "s3"
+    assert numpy.isnan(delta)


### PR DESCRIPTION
[NEW] dvs_delta_jsd constructor requires a reference sequence collection
    as an input argument along with moltype and k. The app takes one
    sequence as input and returns the name and delta-jsd for that sequence.

[NEW] Documented the app.

## Summary by Sourcery

Introduce a new application to calculate delta JSD for individual sequences, extend the SummedRecords API with a delta_jsd method, register the app in the entry points, and update the documentation with usage examples

New Features:
- Added dvs_delta_jsd app for computing the delta Jensen–Shannon divergence of a single sequence against a reference set

Enhancements:
- Introduced delta_jsd method on SummedRecords and refactored increases_jsd to use it

Build:
- Registered dvs_delta_jsd as an entry point in the project configuration

Documentation:
- Documented the usage of dvs_delta_jsd in the apps guide