### PR TITLE
Prep for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "diverse_seq"
-version = "2026.3.1"
+version = "2026.4.20"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pyo3 = { version = "0.27.0", features = ["extension-module"], optional = true }
-zarrs = { version = "0.22.10", features = ["zstd"] }
-zarrs_storage = { version = "0.4.0" }
-rustc-hash = "2.0"
+pyo3 = { version = "0.28.3", features = ["extension-module"], optional = true }
+zarrs = { version = "0.23.10", features = ["zstd"] }
+zarrs_storage = { version = "0.4.3" }
+rustc-hash = "2.1.2"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 serde = { version = "1.0", features = ["derive"] }
 postcard = { version = "1.0", features = ["alloc"] }
-serde_json = "1.0.148"
+serde_json = "1.0.149"
 
 [features]
 default = ["python"]
@@ -22,4 +22,4 @@ rust-only = []       # this allows testing rust-only code
 
 [dev-dependencies]
 rstest = "0.26.1"
-tempfile = "3.24.0"
+tempfile = "3.27.0"

--- a/diverse_seq/__init__.py
+++ b/diverse_seq/__init__.py
@@ -13,7 +13,7 @@ if typing.TYPE_CHECKING:
     from cogent3.core.alignment import SequenceCollection
 
 # change version in Cargo.toml as well
-__version__ = "2026.3.1"
+__version__ = "2026.4.20"
 
 
 def load_sample_data() -> "SequenceCollection":

--- a/diverse_seq/cli.py
+++ b/diverse_seq/cli.py
@@ -26,6 +26,7 @@ if typing.TYPE_CHECKING:
     from click.core import Context, Option
 
 LOGGER = CachingLogger()
+snxpar.set_parallel_backend("multiprocess")
 
 
 def _get_seed(ctx: "Context", param: "Option", value: str | None) -> int:

--- a/docs/hooks/env.py
+++ b/docs/hooks/env.py
@@ -1,0 +1,3 @@
+import os
+
+os.environ["DVS_HIDE_PROGRESS"] = "1"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,9 @@ theme:
         - text
         - bash
 
+hooks:
+    - docs/hooks/env.py
+
 plugins:
     - mkdocs-jupyter:
         allow_errors: false

--- a/src/zarr_io.rs
+++ b/src/zarr_io.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use xxhash_rust::xxh3::xxh3_64;
 use zarrs::array::codec::ZstdCodec;
-use zarrs::array::{Array, ArrayBuilder, DataType, FillValue};
+use zarrs::array::{Array, ArrayBuilder, FillValue, data_type};
 use zarrs::filesystem::FilesystemStore;
 use zarrs_storage::store::MemoryStore;
 
@@ -241,7 +241,7 @@ impl ZarrStore {
         let mut array_builder = ArrayBuilder::new(
             vec![data_len],
             vec![chunk_size],
-            DataType::UInt8,
+            data_type::uint8(),
             FillValue::from(0u8),
         );
         let array_builder = if metadata.is_some() {


### PR DESCRIPTION
## Summary by Sourcery

Prepare the project for a new release with updated versions and minor behavior/configuration adjustments.

Enhancements:
- Set snxpar to use the multiprocess backend by default in the CLI.
- Adjust Zarr array construction to use the typed uint8 data_type helper instead of the raw enum.

Build:
- Bump the crate version and align the Python package version for the new release.
- Update Rust dependencies and dev-dependencies to newer compatible versions.

Documentation:
- Configure MkDocs to use a custom documentation hook module.