### PR TITLE
TST: fix broken fixture

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,7 +37,8 @@ def runner():
 
 @pytest.fixture(scope="function")
 def rna_seq_path(tmp_dir, seq_path):
-    seqs = load_unaligned_seqs(seq_path, moltype="rna")
+    seqs = load_unaligned_seqs(seq_path, moltype="dna")
+    seqs = seqs.to_rna()
     path = tmp_dir / "test_rna.fasta"
     seqs.write(path)
     return path


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Fix RNA sequence test fixture to load DNA sequences and convert them to RNA prior to writing the temporary FASTA file.