### PR TITLE
DEV: add cooldown period for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,13 @@ updates:
       interval: weekly
       time: "19:00"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       time: "19:00"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary by Sourcery

Configure a cooldown period for Dependabot updates across npm and GitHub Actions ecosystems to limit how frequently new pull requests are opened.

Build:
- Add a 7-day default cooldown for Dependabot npm updates.
- Add a 7-day default cooldown for Dependabot GitHub Actions updates.